### PR TITLE
Fixed warning not having right height

### DIFF
--- a/public/css/downloads.css
+++ b/public/css/downloads.css
@@ -215,4 +215,5 @@ nav a {
 .versionWarning.visible {
   min-height: min-content;
   padding: 10px;
+  max-height: none;
 }


### PR DESCRIPTION
On https://purpurmc.org/downloads?v=1.18 with Chrome on Windows the warning doesn't have the right height because the max hight is limiting. By specifying the heigt in the _visible_ CSS part, the warning is dislayed correctly.