### PR TITLE
Update Minecraft wiki references

### DIFF
--- a/public/images/purpur-glow-squid.svg
+++ b/public/images/purpur-glow-squid.svg
@@ -27,5 +27,5 @@
     to="360 50 50" 
     repeatCount="indefinite" />
  </g>
- <image transform="rotate(30) translate(-12,-62)" x="50%" y="50%" width="60" height="60" xlink:href="https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/c3/Glow_Squid_JE1.gif"/>
+ <image transform="rotate(30) translate(-12,-62)" x="50%" y="50%" width="60" height="60" xlink:href="https://minecraft.wiki/images/Glow_Squid_JE1.gif?dcad8"/>
 </svg>

--- a/public/images/purpur-pride-glow-squid.svg
+++ b/public/images/purpur-pride-glow-squid.svg
@@ -46,6 +46,6 @@
     to="360 50 50" 
     repeatCount="indefinite" />
  </g>
-<image transform="rotate(30) translate(-12,-62)" x="50%" y="50%" width="60" height="60" xlink:href="https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/c3/Glow_Squid_JE1.gif"/>
+<image transform="rotate(30) translate(-12,-62)" x="50%" y="50%" width="60" height="60" xlink:href="https://minecraft.wiki/images/Glow_Squid_JE1.gif?dcad8"/>
 
 </svg> 

--- a/public/images/purpur-pride-squid.svg
+++ b/public/images/purpur-pride-squid.svg
@@ -46,6 +46,6 @@
     to="360 50 50" 
     repeatCount="indefinite" />
  </g>
- <image transform="rotate(30) translate(-12,-62)" x="50%" y="50%" width="60" height="60" xlink:href="https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/ce/Squid.gif"/>
+ <image transform="rotate(30) translate(-12,-62)" x="50%" y="50%" width="60" height="60" xlink:href="https://minecraft.wiki/images/Squid.gif?8a4c4"/>
 
 </svg>

--- a/public/images/purpur-squid.svg
+++ b/public/images/purpur-squid.svg
@@ -27,5 +27,5 @@
     to="360 50 50" 
     repeatCount="indefinite" />
  </g>
- <image transform="rotate(30) translate(-12,-62)" x="50%" y="50%" width="60" height="60" xlink:href="https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/ce/Squid.gif"/>
+ <image transform="rotate(30) translate(-12,-62)" x="50%" y="50%" width="60" height="60" xlink:href="https://minecraft.wiki/images/Squid.gif?8a4c4"/>
 </svg>


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all references accordingly.